### PR TITLE
add settings for emoji autocomplete trigger character

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,41 @@
 import joplin from 'api';
-import {ContentScriptType} from "../api/types";
+import {ContentScriptType, SettingItemType} from "../api/types";
+
+export const SETTING_TRIGGER_CHARACTER = 'settingTriggerCharacter';
 
 joplin.plugins.register({
     onStart: async function () {
 
-
+        const section = 'markdownEmojiAutocompleteSection';
         const contentScriptId = 'de-pernpas-joplin-markdown-emoji-autocomplete';
 
-        joplin.contentScripts.register(
+        await joplin.settings.registerSection(section, {
+            label: 'Markdown Emoji Autocomplete',
+            iconName: 'fas fa-smile'
+        });
+
+        await joplin.settings.registerSettings({
+            [SETTING_TRIGGER_CHARACTER]: {
+                value: ':',
+                type: SettingItemType.String,
+                section: section,
+                public: true,
+                label: 'Enable Emoji Autocomplete on Character',
+                description: 'Specifies the character that triggers emoji autocomplete. Note: The pop-up appears after typing the first character, so using a frequently used character like ":" may disrupt regular typing.',
+            },
+        });
+
+        await joplin.contentScripts.register(
             ContentScriptType.CodeMirrorPlugin,
             contentScriptId,
             './markdownEmojiAutocompleteScript.js', // JS file is built from src/contentScript.ts
         );
+
+        // Handle messages from the content script
+        await joplin.contentScripts.onMessage(contentScriptId, async (message: string) => {
+            if (message === 'getTriggerCharacter') {
+                return await joplin.settings.value(SETTING_TRIGGER_CHARACTER) ?? ':';
+            }
+        });
     },
 });

--- a/src/markdownEmojiAutocompleteScript.ts
+++ b/src/markdownEmojiAutocompleteScript.ts
@@ -10,11 +10,15 @@ export default (context: { contentScriptId: string, postMessage: any }) => {
 
             console.info('content script loaded');
 
+            // Get the setting from the main plugin via postMessage
+            const triggerCharacter = await context.postMessage('getTriggerCharacter');
+            console.info(`trigger character loaded: ${triggerCharacter}`);
+
             const completionSource = Object.entries(emojiKeyToUnicodeMapping).map(([key, unicode]) => {
                 const codePoints = unicode.split('-').map(hex => parseInt(hex, 16));
                 const emoji = String.fromCodePoint(...codePoints);
                 return {
-                    label: `:${key}:` + emoji,
+                    label: `${triggerCharacter}${key}${triggerCharacter}${emoji}`,
                     apply: emoji,
                 };
             });


### PR DESCRIPTION
This pull request introduces a user-configurable setting for the character that triggers emoji autocomplete in Markdown, making the feature more flexible and less intrusive for users. The setting is exposed in the plugin's settings UI, and the content script now dynamically retrieves this value from the main plugin.

**Settings and configuration improvements:**

* Added a new plugin setting (`settingTriggerCharacter`) that allows users to specify which character triggers emoji autocomplete, with a default value of `:`. This setting is registered in a dedicated section in the plugin's settings UI.
* The content script now requests the current trigger character from the main plugin via message passing, ensuring that the autocomplete feature uses the user-selected character. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L2-R39) [[2]](diffhunk://#diff-e45835ff08341ce15e0833c1a090a235012183c99b0fcd60b9efe7c3639e60c5R13-R21)

**Autocomplete behavior update:**

* Emoji completion labels in the autocomplete now use the configured trigger character instead of the hardcoded `:` character, making the feature adapt to user preferences.